### PR TITLE
Update .packit.yml to support new packit release 1.0.0

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -6,7 +6,7 @@ downstream_package_name: libmodulemd
 actions:
   get-current-version: ./get_version.sh
 
-synced_files:
+files_to_sync:
   - fedora/
   - .packit.yaml
 


### PR DESCRIPTION
Packit 1.0.0 does not support deprecated synced_files key anymore. 
`synced_files` has been substituted by [files_to_sync](https://packit.dev/docs/configuration#files_to_sync).

More details can be found [here](https://packit.dev/posts/packit_1_0_0_action_required).

Please, merge this PR in a week. Packit upstream CI will fail otherwise.